### PR TITLE
fix/fixed-vec-implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["data-structures", "algorithms", "no-std"]
 arrayvec = { version = "0.7.6", default-features = false, optional = true }
 ndarray = { version = "0.16.1", default-features = false, optional = true }
 orx-fixed-vec = { version = "3.14.0", default-features = false, optional = true }
+orx-iterable = { version = "1.1.1", default-features = false }
 orx-split-vec = { version = "3.14.0", default-features = false, optional = true }
 smallvec = { version = "1.13.2", default-features = false, optional = true }
 tinyvec = { version = "1.8.1", default-features = false, optional = true, features = [

--- a/src/impl_nvec_mut/orx_fixed_vec.rs
+++ b/src/impl_nvec_mut/orx_fixed_vec.rs
@@ -1,5 +1,6 @@
 use crate::{impl_v1_mut, impl_vn_mut, D2, D3, D4};
 use orx_fixed_vec::*;
+use orx_iterable::CollectionMut;
 
 impl_v1_mut!([T], FixedVec<T>, [T: Copy]);
 impl_vn_mut!(D2, [T, C], FixedVec<C>, [C: NVecMut<<D2 as Dim>::PrevDim, T>]);


### PR DESCRIPTION
Missing import is added to fixed vec implementation that is required by iter_mut call.